### PR TITLE
support to export as custom element

### DIFF
--- a/src/js/pose_viewer/package.json
+++ b/src/js/pose_viewer/package.json
@@ -19,7 +19,8 @@
     "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec --e2e",
     "test.watch": "stencil test --spec --e2e --watchAll",
-    "generate": "stencil generate"
+    "generate": "stencil generate",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@stencil/core": "4.5.0",

--- a/src/js/pose_viewer/stencil.config.ts
+++ b/src/js/pose_viewer/stencil.config.ts
@@ -18,6 +18,10 @@ export const config: Config = {
     {
       type: 'www',
       serviceWorker: null // disable service workers
+    },
+    { 
+      type: 'dist-custom-elements', 
+      externalRuntime: false 
     }
   ]
 };


### PR DESCRIPTION
Why Add the prepare Script?

> prepare: This script runs automatically before the package is packed and published to the npm registry, and it also runs when you install the package from GitHub. This ensures that the build process (npm run build) happens before the package is used.

and according to https://www.npmjs.com/package/@stencil/react-output-target

> dist-custom-elements output target is required for the React output target