### PR TITLE
add testing for python 3.9-3.12

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Currently all tests run on 3.8, which is [end-of-life](https://devguide.python.org/versions/). Eventually we'll probably wish to drop support, so in prep for that it would be good to add testing on newer versions