### PR TITLE
fix masking issue in interpolate

### DIFF
--- a/src/python/pose_format/numpy/pose_body.py
+++ b/src/python/pose_format/numpy/pose_body.py
@@ -339,18 +339,13 @@ class NumPyPoseBody(PoseBody):
         for people in points:
             new_frames = []
             for frames in people:
-                mask = frames.transpose()[-1].mask
-                # print(mask)
+                mask = frames.transpose()[-1].mask # takes mask from confidence value
 
                 partial_steps = ma.array(steps, mask=mask).compressed()
 
                 if partial_steps.shape[0] == 0:  # No data for this point
                     new_frames.append(np.zeros((_new_frames, frames.shape[1])))
                 else:
-                    # print(frames)
-                    # print(frames.shape)
-                    # print(frames.compressed().shape)
-                    # print(partial_steps.shape)
                     partial_frames = frames.compressed().reshape(partial_steps.shape[0], frames.shape[1])
 
                     if len(partial_steps) == 1:

--- a/src/python/pose_format/numpy/pose_body.py
+++ b/src/python/pose_format/numpy/pose_body.py
@@ -339,13 +339,18 @@ class NumPyPoseBody(PoseBody):
         for people in points:
             new_frames = []
             for frames in people:
-                mask = frames.transpose()[0].mask
+                mask = frames.transpose()[-1].mask
+                # print(mask)
 
                 partial_steps = ma.array(steps, mask=mask).compressed()
 
                 if partial_steps.shape[0] == 0:  # No data for this point
                     new_frames.append(np.zeros((_new_frames, frames.shape[1])))
                 else:
+                    # print(frames)
+                    # print(frames.shape)
+                    # print(frames.compressed().shape)
+                    # print(partial_steps.shape)
                     partial_frames = frames.compressed().reshape(partial_steps.shape[0], frames.shape[1])
 
                     if len(partial_steps) == 1:


### PR DESCRIPTION
I have found this strange bug: when the x, y, z, and confidence are all 0s for a point in a pose (everything should be masked), but the current implementation on line 342 would not consider it masked when reading the first dimension (the x is 0).

I did not have this issue before, so I assume the pose data should always have masked x, y, and z values when the confidence is 0, @AmitMY is it what we should expect for a "normal" pose?
