### PR TITLE
add beginner tutorial link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ At the core of the file format is `Header` and a `Body`.
 
 More about the header and the body details and their binary specifics can be found in [docs/specs/v0.1.md](specs_v01.rst#specs_v01).
 
+### Tutorials
+
+For a step-by-step tutorial with practical examples for beginners, see [pose-format-tutorials](https://github.com/24-mohamedyehia/pose-format-tutorials).
+
 ### Python Usage Guide: 
 
 #### 1. Installation: 


### PR DESCRIPTION
As discussed in #215 , I have updated the notebooks to be fully compatible with Google Colab and added "Open in Colab" badges.

This PR adds a link to the tutorials in the README.md file under the "Tutorials" section to help beginners get started easily.
