### PR TITLE
Fix flaky normalize_distribution test (float32 tolerance)

### DIFF
--- a/src/python/tests/pose_tensorflow_test.py
+++ b/src/python/tests/pose_tensorflow_test.py
@@ -133,7 +133,9 @@ class TestPoseTensorflowPoseBody(TestCase):
         actual_tensor_zero_filled = actual_tensor_nan_fixed.zero_filled()
         actual_tensor_as_numpy = actual_tensor_zero_filled.numpy()
 
-        self.assertTrue(np.allclose(actual_tensor_as_numpy, expected_tensor),
+        # actual is float32 (TF), expected is float64 (numpy); atol must tolerate
+        # float32 rounding on near-zero values, where allclose's default 1e-8 is too tight.
+        self.assertTrue(np.allclose(actual_tensor_as_numpy, expected_tensor, atol=1e-4),
                         "Normalize distribution did not return the expected result.")
 
     def test_pose_tf_posebody_frame_dropout_normal_eager_mode_num_frames_not_zero(self):


### PR DESCRIPTION
## Problem

`pose_tensorflow_test.py::test_pose_tf_posebody_normalize_distribution_eager_mode_correct_result` flakes ~2% of runs (it's what failed on #226's PR CI).

It compares `normalize_distribution` output — **float32**, from the TensorFlow pose body — against a NumPy reference computed in **float64**, using `np.allclose` with its default `atol=1e-8`. On near-zero normalized values, float32 rounding error (~1e-7…1e-5) exceeds that tolerance and the assertion fails, depending on the random mask/data drawn that run.

## Investigation

Reproduced locally at **6/300 runs**. Captured a failing case: max absolute difference was **~1e-5**, on an expected value of ~0.0018 — never a logic error, purely dtype precision. `act` dtype `float32`, `exp` dtype `float64`.

Tolerance sweep over 5000 trials each:

| atol | fails |
|------|-------|
| default (1e-8) | flaky |
| 1e-6 | 4/5000 |
| 5e-6 | 0/5000 |
| 1e-5 | 0/5000 (worst diff spiked ~1.1e-5 in another sweep) |

## Fix

Use `atol=1e-4` — comfortably above float32 noise, yet still 4 orders of magnitude tighter than any real regression (the output is z-scores, O(1)). 30× reruns of the test: 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)