### PR TITLE
Add MMPose wholebody estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,16 +228,11 @@ Normalizing the pose  before creating the mp4 output file (`--normalize`) is opt
 
 #### 6. Integration with External Data Sources:
 
-Loaders are available for several pose estimators:
+If you have pose data in OpenPose (usually folders of JSON files, one per frame) format, you can easily import it. 
 
-| Estimator | Support |
-|---|---|
-| OpenPose | core |
-| AlphaPose WholeBody | experimental |
+##### Loading OpenPose Data
 
-##### OpenPose
-
-To load an OpenPose `directory` (one JSON file per frame):
+To load an OpenPose `directory`, use the `load_openpose_directory` utility:
 
 * For the 137-keypoint OpenPose model:
 
@@ -257,7 +252,7 @@ directory = "/path/to/openpose_135/directory"
 pose = load_openpose_135_directory(directory, fps=24, width=1000, height=1000)
 ```
 
-##### AlphaPose WholeBody
+##### Loading AlphaPose WholeBody JSON
 
 ```python
 from pose_format.utils.alphapose import load_alphapose_wholebody_from_json

--- a/README.md
+++ b/README.md
@@ -232,10 +232,8 @@ Loaders are available for several pose estimators:
 
 | Estimator | Support |
 |---|---|
-| Mediapipe Holistic | core |
 | OpenPose | core |
 | AlphaPose WholeBody | experimental |
-| MMPose WholeBody | experimental |
 
 ##### OpenPose
 
@@ -273,20 +271,6 @@ For the 133-keypoint variant:
 from pose_format.utils.alphapose_133 import load_alphapose_wholebody_from_json as load_alphapose_133
 
 pose = load_alphapose_133("alphapose.json")
-```
-
-##### MMPose WholeBody
-
-Requires MMPose and its dependencies, install the `pose` library with an additional target:
-
-```bash
-pip install pose-format[mmpose]
-```
-
-```python
-from pose_format.utils.mmposewholebody import load_mmposewholebody
-
-pose = load_mmposewholebody("video.mp4", fps=25, width=1920, height=1080)
 ```
 
 #### 7. Generating Fake Pose Data for Testing Purposes:

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Loaders are available for several pose estimators:
 
 | Estimator | Support |
 |---|---|
+| Mediapipe Holistic | core |
 | OpenPose | core |
 | AlphaPose WholeBody | experimental |
 | MMPose WholeBody | experimental |
@@ -276,13 +277,11 @@ pose = load_alphapose_133("alphapose.json")
 
 ##### MMPose WholeBody
 
-Requires MMPose and its dependencies. For GPU use, `mmcv` must be installed from the OpenMMLab CUDA-specific index — plain `pip install mmcv` installs a CPU-only build. See the [mmcv installation guide](https://mmcv.readthedocs.io/en/latest/get_started/installation.html) for the right command for your CUDA and PyTorch versions. The remaining packages can be installed with pip:
+Requires MMPose and its dependencies, install the `pose` library with an additional target:
 
 ```bash
-pip install mmpose>=1.3.2 mmengine>=0.10.7 mmdet>=3.3.0
+pip install pose-format[mmpose]
 ```
-
-Then run inference directly on a video file:
 
 ```python
 from pose_format.utils.mmposewholebody import load_mmposewholebody

--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ Normalizing the pose  before creating the mp4 output file (`--normalize`) is opt
 
 #### 6. Integration with External Data Sources:
 
-If you have pose data in OpenPose (usually folders of JSON files, one per frame) format, you can easily import it. 
+Loaders are available for several pose estimators. **OpenPose** support is core and well-tested. Support for additional estimators is **experimental** — APIs may evolve and edge cases may not yet be fully handled.
 
-##### Loading OpenPose Data
+##### Core: OpenPose
 
-To load an OpenPose `directory`, use the `load_openpose_directory` utility:
+To load an OpenPose `directory` (one JSON file per frame):
 
 * For the 137-keypoint OpenPose model:
 
@@ -252,7 +252,7 @@ directory = "/path/to/openpose_135/directory"
 pose = load_openpose_135_directory(directory, fps=24, width=1000, height=1000)
 ```
 
-##### Loading AlphaPose WholeBody JSON
+##### Experimental: AlphaPose WholeBody
 
 ```python
 from pose_format.utils.alphapose import load_alphapose_wholebody_from_json
@@ -266,6 +266,16 @@ For the 133-keypoint variant:
 from pose_format.utils.alphapose_133 import load_alphapose_wholebody_from_json as load_alphapose_133
 
 pose = load_alphapose_133("alphapose.json")
+```
+
+##### Experimental: MMPose WholeBody
+
+Requires MMPose and its dependencies (`pip install mmpose mmcv mmengine mmdet`). Runs inference directly on a video file:
+
+```python
+from pose_format.utils.mmposewholebody import load_mmposewholebody
+
+pose = load_mmposewholebody("video.mp4", fps=25, width=1920, height=1080)
 ```
 
 #### 7. Generating Fake Pose Data for Testing Purposes:

--- a/README.md
+++ b/README.md
@@ -270,7 +270,13 @@ pose = load_alphapose_133("alphapose.json")
 
 ##### Experimental: MMPose WholeBody
 
-Requires MMPose and its dependencies (`pip install mmpose mmcv mmengine mmdet`). Runs inference directly on a video file:
+Requires MMPose and its dependencies. For GPU use, `mmcv` must be installed from the OpenMMLab CUDA-specific index — plain `pip install mmcv` installs a CPU-only build. See the [mmcv installation guide](https://mmcv.readthedocs.io/en/latest/get_started/installation.html) for the right command for your CUDA and PyTorch versions. The remaining packages can be installed with pip:
+
+```bash
+pip install mmpose>=1.3.2 mmengine>=0.10.7 mmdet>=3.3.0
+```
+
+Then run inference directly on a video file:
 
 ```python
 from pose_format.utils.mmposewholebody import load_mmposewholebody

--- a/README.md
+++ b/README.md
@@ -228,9 +228,15 @@ Normalizing the pose  before creating the mp4 output file (`--normalize`) is opt
 
 #### 6. Integration with External Data Sources:
 
-Loaders are available for several pose estimators. **OpenPose** support is core and well-tested. Support for additional estimators is **experimental** — APIs may evolve and edge cases may not yet be fully handled.
+Loaders are available for several pose estimators:
 
-##### Core: OpenPose
+| Estimator | Support |
+|---|---|
+| OpenPose | core |
+| AlphaPose WholeBody | experimental |
+| MMPose WholeBody | experimental |
+
+##### OpenPose
 
 To load an OpenPose `directory` (one JSON file per frame):
 
@@ -252,7 +258,7 @@ directory = "/path/to/openpose_135/directory"
 pose = load_openpose_135_directory(directory, fps=24, width=1000, height=1000)
 ```
 
-##### Experimental: AlphaPose WholeBody
+##### AlphaPose WholeBody
 
 ```python
 from pose_format.utils.alphapose import load_alphapose_wholebody_from_json
@@ -268,7 +274,7 @@ from pose_format.utils.alphapose_133 import load_alphapose_wholebody_from_json a
 pose = load_alphapose_133("alphapose.json")
 ```
 
-##### Experimental: MMPose WholeBody
+##### MMPose WholeBody
 
 Requires MMPose and its dependencies. For GPU use, `mmcv` must be installed from the OpenMMLab CUDA-specific index — plain `pip install mmcv` installs a CPU-only build. See the [mmcv installation guide](https://mmcv.readthedocs.io/en/latest/get_started/installation.html) for the right command for your CUDA and PyTorch versions. The remaining packages can be installed with pip:
 

--- a/src/python/pose_format/utils/mmposewholebody.py
+++ b/src/python/pose_format/utils/mmposewholebody.py
@@ -5,8 +5,9 @@ try:
     from mmpose.apis import MMPoseInferencer
 except ImportError:
     raise ImportError(
-        "Please install MMPose and its dependencies with:\n"
-        "  pip install mmpose mmcv mmengine mmdet"
+        "Please install MMPose and its dependencies. For GPU support, mmcv must be installed\n"
+        "from the OpenMMLab CUDA-specific index (see https://mmcv.readthedocs.io/en/latest/get_started/installation.html).\n"
+        "The remaining packages: pip install 'mmpose>=1.3.2' 'mmengine>=0.10.7' 'mmdet>=3.3.0'"
     )
 
 from ..numpy.pose_body import NumPyPoseBody

--- a/src/python/pose_format/utils/mmposewholebody.py
+++ b/src/python/pose_format/utils/mmposewholebody.py
@@ -18,7 +18,7 @@ from .cocowholebody133_header import cocowholebody_components
 NUM_KEYPOINTS = 133
 
 
-def load_mmposewholebody(input_path: str,
+def estimate_mmpose_wholebody(input_path: str,
                          version: float = 0.2,
                          fps: float = 24,
                          width: int = 1000,

--- a/src/python/pose_format/utils/mmposewholebody.py
+++ b/src/python/pose_format/utils/mmposewholebody.py
@@ -1,0 +1,112 @@
+import numpy as np
+import numpy.ma as ma
+
+try:
+    from mmpose.apis import MMPoseInferencer
+except ImportError:
+    raise ImportError(
+        "Please install MMPose and its dependencies with:\n"
+        "  pip install mmpose mmcv mmengine mmdet"
+    )
+
+from ..numpy.pose_body import NumPyPoseBody
+from ..pose import Pose
+from ..pose_header import PoseHeader, PoseHeaderDimensions
+from .cocowholebody133_header import cocowholebody_components
+
+NUM_KEYPOINTS = 133
+
+
+def load_mmposewholebody(input_path: str,
+                         version: float = 0.2,
+                         fps: float = 24,
+                         width: int = 1000,
+                         height: int = 1000,
+                         depth: int = 0) -> Pose:
+    """
+    Run MMPose wholebody inference on a video and return a Pose object.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to the input video file.
+    version : float
+        Pose format version written to the header.
+    fps : float
+        Frames per second stored in the pose body.
+    width : int
+        Frame width in pixels stored in the header dimensions.
+    height : int
+        Frame height in pixels stored in the header dimensions.
+    depth : int
+        Depth dimension size (0 for 2D poses).
+
+    Returns
+    -------
+    Pose
+        Loaded pose with header and body.
+    """
+    header = PoseHeader(
+        version=version,
+        dimensions=PoseHeaderDimensions(width=width, height=height, depth=depth),
+        components=cocowholebody_components(),
+    )
+    body = _process_video(input_path, fps)
+    return Pose(header, body)
+
+
+def _process_video(input_path: str, fps: float, use_cpu: bool = False) -> NumPyPoseBody:
+    """
+    Run MMPose wholebody inference and convert frame results to NumPyPoseBody.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to the input video file.
+    fps : float
+        Frames per second to store in the pose body.
+    use_cpu : bool
+        If True, run inference on CPU (slow; useful when no GPU is available).
+
+    Returns
+    -------
+    NumPyPoseBody
+    """
+    device = 'cpu' if use_cpu else None
+    inferencer_kwargs = {'wholebody': True}
+    if device is not None:
+        inferencer_kwargs['device'] = device
+
+    inferencer = MMPoseInferencer('wholebody', **({'device': device} if device else {}))
+    result_generator = inferencer(input_path, show=False, return_vis=False)
+
+    frames_xy = []
+    frames_conf = []
+    frames_mask = []  # True = valid, False = masked out (no detection)
+
+    for result in result_generator:
+        predictions_by_frame = result['predictions']  # list of per-person dicts for this frame
+
+        if len(predictions_by_frame) == 0 or len(predictions_by_frame[0]) == 0:
+            # No person detected in this frame. Insert a zeroed, fully-masked row so
+            # the frame count stays aligned with the video. Callers can distinguish
+            # "no detection" from a real zero-coordinate keypoint via the mask.
+            frames_xy.append(np.zeros((1, NUM_KEYPOINTS, 2), dtype=np.float32))
+            frames_conf.append(np.zeros((1, NUM_KEYPOINTS), dtype=np.float32))
+            frames_mask.append(True)   # True = mask this frame entirely
+        else:
+            person = predictions_by_frame[0][0]
+            frames_xy.append(np.array(person['keypoints'], dtype=np.float32)[None])    # (1, 133, 2)
+            frames_conf.append(np.array(person['keypoint_scores'], dtype=np.float32)[None])  # (1, 133)
+            frames_mask.append(False)  # False = keep (not masked)
+
+    xy_data = np.concatenate(frames_xy, axis=0)[:, None, :, :]    # (T, 1, 133, 2)
+    conf_data = np.concatenate(frames_conf, axis=0)[:, None, :]   # (T, 1, 133)
+
+    # Build the masked array: mask=True on empty frames so downstream code
+    # can treat them as missing rather than as detected-at-origin.
+    mask = np.array(frames_mask)                                    # (T,)
+    xy_mask = mask[:, None, None, None] * np.ones_like(xy_data, dtype=bool)
+    masked_xy = ma.array(xy_data, mask=xy_mask)
+
+    return NumPyPoseBody(fps=fps, data=masked_xy, confidence=conf_data)

--- a/src/python/pose_format/utils/mmposewholebody_test.py
+++ b/src/python/pose_format/utils/mmposewholebody_test.py
@@ -12,7 +12,7 @@ for _mod in ["mmpose", "mmpose.apis", "mmcv", "mmengine", "mmdet"]:
     sys.modules.setdefault(_mod, MagicMock())
 
 from pose_format.utils import mmposewholebody  # noqa: E402 — must come after the stubs above
-from pose_format.utils.mmposewholebody import load_mmposewholebody  # noqa: E402
+from pose_format.utils.mmposewholebody import estimate_mmpose_wholebody  # noqa: E402
 from pose_format.utils.cocowholebody133_header import cocowholebody_components  # noqa: E402
 
 NUM_KEYPOINTS = 133
@@ -70,7 +70,7 @@ def test_load_shape(monkeypatch, tmp_path):
     """Output Pose has the right frame/keypoint shape."""
     monkeypatch.setattr(mmposewholebody, "MMPoseInferencer",
                         _make_inferencer([_fake_result(), _fake_result(), _fake_result()]))
-    pose = load_mmposewholebody(str(tmp_path / "video.mp4"), fps=25.0, width=1280, height=720)
+    pose = estimate_mmpose_wholebody(str(tmp_path / "video.mp4"), fps=25.0, width=1280, height=720)
 
     assert pose.body.data.shape == (3, 1, NUM_KEYPOINTS, 2)
     assert pose.body.fps == 25.0
@@ -81,7 +81,7 @@ def test_load_shape(monkeypatch, tmp_path):
 def test_load_component_names(monkeypatch, tmp_path):
     monkeypatch.setattr(mmposewholebody, "MMPoseInferencer",
                         _make_inferencer([_fake_result()]))
-    pose = load_mmposewholebody(str(tmp_path / "video.mp4"))
+    pose = estimate_mmpose_wholebody(str(tmp_path / "video.mp4"))
 
     assert [c.name for c in pose.header.components] == ["BODY", "FACE", "LEFT_HAND", "RIGHT_HAND"]
 
@@ -90,7 +90,7 @@ def test_empty_frame_is_masked(monkeypatch, tmp_path):
     """Frames with no detection are present in the output but fully masked."""
     results = [_fake_result(), _empty_result(), _fake_result()]
     monkeypatch.setattr(mmposewholebody, "MMPoseInferencer", _make_inferencer(results))
-    pose = load_mmposewholebody(str(tmp_path / "video.mp4"))
+    pose = estimate_mmpose_wholebody(str(tmp_path / "video.mp4"))
 
     # All three frames must be present so frame count matches the video.
     assert pose.body.data.shape[0] == 3
@@ -105,7 +105,7 @@ def test_all_empty_frames(monkeypatch, tmp_path):
     """A video where no person is ever detected produces a fully masked Pose."""
     results = [_empty_result(), _empty_result()]
     monkeypatch.setattr(mmposewholebody, "MMPoseInferencer", _make_inferencer(results))
-    pose = load_mmposewholebody(str(tmp_path / "video.mp4"))
+    pose = estimate_mmpose_wholebody(str(tmp_path / "video.mp4"))
 
     assert pose.body.data.shape[0] == 2
     assert pose.body.data.mask.all()
@@ -114,5 +114,5 @@ def test_all_empty_frames(monkeypatch, tmp_path):
 def test_version_default(monkeypatch, tmp_path):
     monkeypatch.setattr(mmposewholebody, "MMPoseInferencer",
                         _make_inferencer([_fake_result()]))
-    pose = load_mmposewholebody(str(tmp_path / "video.mp4"))
+    pose = estimate_mmpose_wholebody(str(tmp_path / "video.mp4"))
     assert pose.header.version == 0.2

--- a/src/python/pose_format/utils/mmposewholebody_test.py
+++ b/src/python/pose_format/utils/mmposewholebody_test.py
@@ -1,0 +1,118 @@
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import numpy.ma as ma
+import pytest
+
+# Stub the MMPose package and its dependencies before our module is imported.
+# mmposewholebody.py does `from mmpose.apis import MMPoseInferencer` at module level,
+# so sys.modules must be populated before the first import of that module.
+for _mod in ["mmpose", "mmpose.apis", "mmcv", "mmengine", "mmdet"]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+from pose_format.utils import mmposewholebody  # noqa: E402 — must come after the stubs above
+from pose_format.utils.mmposewholebody import load_mmposewholebody  # noqa: E402
+from pose_format.utils.cocowholebody133_header import cocowholebody_components  # noqa: E402
+
+NUM_KEYPOINTS = 133
+
+
+# ---------------------------------------------------------------------------
+# Header / components tests — no MMPose installation required
+# ---------------------------------------------------------------------------
+
+def test_components_total_keypoints():
+    assert sum(len(c.points) for c in cocowholebody_components()) == NUM_KEYPOINTS
+
+
+def test_components_names():
+    names = [c.name for c in cocowholebody_components()]
+    assert names == ["BODY", "FACE", "LEFT_HAND", "RIGHT_HAND"]
+
+
+def test_components_point_format():
+    for c in cocowholebody_components():
+        assert c.format == "XYC"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_result(num_keypoints: int = NUM_KEYPOINTS):
+    """Single-frame MMPose result with one detected person."""
+    return {
+        "predictions": [[{
+            "keypoints": np.random.rand(num_keypoints, 2).tolist(),
+            "keypoint_scores": np.random.rand(num_keypoints).tolist(),
+        }]]
+    }
+
+
+def _empty_result():
+    """Single-frame MMPose result with no detected person."""
+    return {"predictions": []}
+
+
+def _make_inferencer(results):
+    """Return a patched MMPoseInferencer class whose instance yields `results`."""
+    fake_instance = MagicMock()
+    fake_instance.return_value = iter(results)
+    return MagicMock(return_value=fake_instance)
+
+
+# ---------------------------------------------------------------------------
+# Loader tests (MMPoseInferencer is mocked)
+# ---------------------------------------------------------------------------
+
+def test_load_shape(monkeypatch, tmp_path):
+    """Output Pose has the right frame/keypoint shape."""
+    monkeypatch.setattr(mmposewholebody, "MMPoseInferencer",
+                        _make_inferencer([_fake_result(), _fake_result(), _fake_result()]))
+    pose = load_mmposewholebody(str(tmp_path / "video.mp4"), fps=25.0, width=1280, height=720)
+
+    assert pose.body.data.shape == (3, 1, NUM_KEYPOINTS, 2)
+    assert pose.body.fps == 25.0
+    assert pose.header.dimensions.width == 1280
+    assert pose.header.dimensions.height == 720
+
+
+def test_load_component_names(monkeypatch, tmp_path):
+    monkeypatch.setattr(mmposewholebody, "MMPoseInferencer",
+                        _make_inferencer([_fake_result()]))
+    pose = load_mmposewholebody(str(tmp_path / "video.mp4"))
+
+    assert [c.name for c in pose.header.components] == ["BODY", "FACE", "LEFT_HAND", "RIGHT_HAND"]
+
+
+def test_empty_frame_is_masked(monkeypatch, tmp_path):
+    """Frames with no detection are present in the output but fully masked."""
+    results = [_fake_result(), _empty_result(), _fake_result()]
+    monkeypatch.setattr(mmposewholebody, "MMPoseInferencer", _make_inferencer(results))
+    pose = load_mmposewholebody(str(tmp_path / "video.mp4"))
+
+    # All three frames must be present so frame count matches the video.
+    assert pose.body.data.shape[0] == 3
+
+    # Frame 1 (index 1) must be fully masked; frames 0 and 2 must not be.
+    assert pose.body.data[1].mask.all(), "empty frame should be fully masked"
+    assert not pose.body.data[0].mask.all(), "detected frame should not be fully masked"
+    assert not pose.body.data[2].mask.all(), "detected frame should not be fully masked"
+
+
+def test_all_empty_frames(monkeypatch, tmp_path):
+    """A video where no person is ever detected produces a fully masked Pose."""
+    results = [_empty_result(), _empty_result()]
+    monkeypatch.setattr(mmposewholebody, "MMPoseInferencer", _make_inferencer(results))
+    pose = load_mmposewholebody(str(tmp_path / "video.mp4"))
+
+    assert pose.body.data.shape[0] == 2
+    assert pose.body.data.mask.all()
+
+
+def test_version_default(monkeypatch, tmp_path):
+    monkeypatch.setattr(mmposewholebody, "MMPoseInferencer",
+                        _make_inferencer([_fake_result()]))
+    pose = load_mmposewholebody(str(tmp_path / "video.mp4"))
+    assert pose.header.version == 0.2

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -34,10 +34,10 @@ mediapipe = [
 ]
 
 mmpose = [
-    "mmcv>=2.0.0",
-    "mmengine>=0.7.0",
-    "mmdet>=3.0.0",
-    "mmpose>=1.0.0",
+    "mmcv>=2.1.0",
+    "mmengine>=0.10.7",
+    "mmdet>=3.3.0",
+    "mmpose>=1.3.2",
 ]
 
 [tool.setuptools]

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -33,6 +33,13 @@ mediapipe = [
     "mediapipe<0.10.30",
 ]
 
+mmpose = [
+    "mmcv>=2.0.0",
+    "mmengine>=0.7.0",
+    "mmdet>=3.0.0",
+    "mmpose>=1.0.0",
+]
+
 [tool.setuptools]
 packages = [
     "pose_format",


### PR DESCRIPTION
## Summary

This PR adds support for running MMPose wholebody inference on a video and converting the result into the library's `.pose` format.

- **`pose_format/utils/mmposewholebody.py`** — new module with `estimate_mmpose_wholebody(input_path, fps, width, height)`. Runs `MMPoseInferencer('wholebody')` on a video file and returns a `Pose` object using the canonical COCO Wholebody 133 header (from `cocowholebody133_header.py`, introduced in #226). Frames with no detected person are represented as fully-masked zero rows, preserving temporal alignment with the source video.
- **`pose_format/utils/mmposewholebody_test.py`** — 8 unit tests covering header structure, output shape, masked empty frames, and the all-empty-video case. MMPose is stubbed via `sys.modules` so tests run without an actual MMPose installation.
- **`pyproject.toml`** — new `mmpose` optional install target (`pip install pose-format[mmpose]`) with version floors derived from a known-good OpenMMLab 2.x combination.

## Design notes

**Not wired into the CLI** — `video_to_pose` / `videos_to_poses` currently only support mediapipe. MMPose could be added to the CLI later; this PR intentionally keeps that scope separate.

**Format vs. estimator** — MMPose wholebody outputs COCO Wholebody 133 keypoints. A `.pose` file produced by this function is structurally identical to one from any other COCO Wholebody 133 estimator (OpenPifPaf, SDPose, etc.). `detect_known_pose_format` correctly identifies such files as `"coco_wholebody_133"`. MMPose is therefore an estimator that produces an existing named format, not a new format in its own right.

**`mmcv` GPU install caveat** — plain `pip install mmcv` installs a CPU-only build; GPU users need the OpenMMLab CUDA-specific index. The `ImportError` message in the module links to the mmcv install guide.

## Relationship to other PRs

This builds on #226 (COCO Wholebody 133 canonical header). Future PRs will add OpenPifPaf and SDPose estimators using the same header.

## Test plan

- [ ] `pytest src/python/pose_format/utils/mmposewholebody_test.py -v` passes without MMPose installed
- [ ] `pytest src/python/pose_format/utils/generic_test.py -v` passes (no regressions)
- [ ] With MMPose installed: `estimate_mmpose_wholebody("video.mp4", fps=25, width=1920, height=1080)` returns a `Pose` with `detect_known_pose_format` → `"coco_wholebody_133"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)