### PR TITLE
chore(deps): make scipy an optional dependency

### DIFF
--- a/src/python/pose_format/utils/normalization_3d.py
+++ b/src/python/pose_format/utils/normalization_3d.py
@@ -2,7 +2,6 @@ from typing import Tuple
 
 import numpy as np
 import numpy.ma as ma
-from scipy.spatial.transform import Rotation
 
 from pose_format.pose_header import PoseNormalizationInfo
 
@@ -136,8 +135,15 @@ class PoseNormalizer:
         ma.masked_array
             rotated pose
         """
-        r = Rotation.from_euler('z', -angle[..., np.newaxis], degrees=True)  # Clockwise rotation
-        rotated = np.einsum('...ij,...kj->...ik', pose, r.as_matrix()).reshape(pose.shape)
+        theta = np.radians(-angle)  # Clockwise rotation
+        cos, sin = np.cos(theta), np.sin(theta)
+        rotation_matrix = np.zeros((*theta.shape, 3, 3))
+        rotation_matrix[..., 0, 0] = cos
+        rotation_matrix[..., 0, 1] = -sin
+        rotation_matrix[..., 1, 0] = sin
+        rotation_matrix[..., 1, 1] = cos
+        rotation_matrix[..., 2, 2] = 1
+        rotated = np.einsum('...ij,...kj->...ik', pose, rotation_matrix).reshape(pose.shape)
         return ma.masked_array(rotated, pose.mask)
 
     def scale(self, pose: ma.masked_array) -> ma.masked_array:

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -11,7 +11,6 @@ authors = [
 ]
 dependencies = [
     "numpy",
-    "scipy",
     "tqdm",
     "simple-video-utils",
 ]
@@ -21,6 +20,7 @@ requires-python = ">= 3.8"
 dev = [
     "pylint",
     "pytest",
+    "scipy",
     "opencv-python",
     "vidgear",
     "mediapipe<0.10.30",


### PR DESCRIPTION
## Summary
- scipy was a required dependency for just two call sites. `PoseNormalizer.rotate` used `scipy.spatial.transform.Rotation` only to build a z-axis rotation matrix — replaced with an explicit cos/sin matrix in pure numpy, verified numerically identical to scipy's output.
- `NumPyPoseBody.interpolate` genuinely needs `scipy.interpolate.interp1d` for quadratic/cubic splines, but it already imports scipy lazily and raises a helpful `ImportError` — left as-is, so scipy is now needed only if you call `interpolate()`.
- `pyproject.toml`: removed scipy from `dependencies`, added it to the `dev` extra so tests still cover interpolation.

## Test Plan
- [x] `pytest tests pose_format` — 176 passed (tf/torch tests skipped locally: frameworks not installed)
- [x] Numerical check: new numpy rotation matrix matches `Rotation.from_euler('z', ...).as_matrix()` for arbitrary angles
- [x] `pylint pose_format/utils/normalization_3d.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)